### PR TITLE
Changes

### DIFF
--- a/MultiMystery.py
+++ b/MultiMystery.py
@@ -79,9 +79,11 @@ if __name__ == "__main__":
         else:
             basemysterycommand = f"py -{py_version} Mystery.py" #source
 
+        spoiler_option = " --create_spoiler" if  create_spoiler else ""
+        race_option = " --race" if race else ""
         basecommand = f"{basemysterycommand} --multi {len(player_files)} {player_string} " \
-                  f"--names {','.join(player_names)} --enemizercli {enemizer_path} " \
-                  "--create_spoiler" if create_spoiler else "" + " --race" if race else ""
+                  f"--names {','.join(player_names)} --enemizercli {enemizer_path}" \
+                  f"{spoiler_option}{race_option}"
         print(basecommand)
 
         import time
@@ -89,7 +91,7 @@ if __name__ == "__main__":
 
         start = time.perf_counter()
 
-        def get_working_seed():#is a function for automatic deallocation of resources that are no longer needed when the server starts
+        def get_working_seed():#is a function for automatic deallocation of resources that are no longer needed when the server starts            
             parallel_attempts = multi_mystery_options["parallel_attempts"]
 
             def cancel_remaining(starting_at:int = 0):
@@ -97,7 +99,7 @@ if __name__ == "__main__":
                     task_mapping[x].cancel()
 
             if parallel_attempts < 1:
-                import multiprocessing
+            import multiprocessing
                 parallel_attempts = multiprocessing.cpu_count()
 
             pool = concurrent.futures.ThreadPoolExecutor()

--- a/host.yaml
+++ b/host.yaml
@@ -36,9 +36,12 @@ multi_mystery_options:
   #create roms flagged as race roms
   race: 0
   ##Doors options
-  # How many seeds should be rolled in parallel. This is useful for Door Rando, since some to many of them can fail.
-  # set to 0 for it to mimic the amount of hardware threads you have, otherwise use a positive number for the amount of attempts it should do at once
-  parallel_attempts: 0
-  #When using parallel_attempts, this controls if the first one that works in order of starting should be taken, or the first one in order of completion time should be taken
+  # How many cpu threads should be used to roll seeds in parallel.
+  # set to 0 for it to mimic the amount of hardware threads you have, otherwise use a positive number to set the max number of threads in parallel to limit resources used.
+  cpu_threads: 0
+  # How many seeds should be attempted. This is useful for Door Rando, since some to many of them can fail.
+  # set to 0 for it to mimic the amount of hardware threads you have, otherwise use a positive number for the amount of attempts it should do.
+  max_attempts: 0
+  #When using max_attempts, this controls if the first one that works in order of starting should be taken, or the first one in order of completion time should be taken
   #keep in mind, that turning this on, will skew the randomness into "simpler" seeds, as they generate quicker
   take_first_working: False


### PR DESCRIPTION
* Fixed a bug where it was impossible to generate a seed without spoiler log.  (Results in basecommand = "", due to the way the if/else statements worked.)
* Add a way to limit the number of processes that run at once to less than min(32, os.cpu_count() + 4) (python 3.8 rules for default value for max_workers).  (This also explains why I was not seeing your threadripper CPUs ALL at 100% on some of your recent pictures.)