### PR TITLE
Return support for standard dungeon_items option

### DIFF
--- a/Mystery.py
+++ b/Mystery.py
@@ -145,6 +145,8 @@ def roll_settings(weights):
     dungeon_items = get_choice('dungeon_items')
     if dungeon_items == 'full' or dungeon_items == True:
         dungeon_items = 'mcsb'
+    elif dungeon_items == 'standard':
+        dungeon_items = ""
     elif not dungeon_items:
         dungeon_items = ""
 


### PR DESCRIPTION
Sahasrahbot style yaml files still use the simple dungeon_items options of standard, mc, mcs, and full to reflect the website options. The latter 3 are currently handled properly, but standard is currently parsed where it creates small key shuffle only which is not the intended behavior.