### PR TITLE
Force the rom to be reread on reconnect if rom...

### DIFF
--- a/MultiClient.py
+++ b/MultiClient.py
@@ -666,6 +666,7 @@ async def process_server_cmd(ctx : Context, cmd, args):
             ctx.password = None
             await server_auth(ctx, True)
         if 'InvalidRom' in args:
+            ctx.rom = None
             raise Exception(
                 'Invalid ROM detected, please verify that you have loaded the correct rom and reconnect your snes (/snes)')
         if 'SlotAlreadyTaken' in args:


### PR DESCRIPTION
... is not one of the expected player roms.  This is all that was preventing things from being 100% automatic, if an incorrect rom was already loaded in the connected snes state.