### PR TITLE
Add a way to show found items on client/server

### DIFF
--- a/MultiClient.py
+++ b/MultiClient.py
@@ -738,6 +738,11 @@ async def process_server_cmd(ctx : Context, cmd, args):
     elif cmd == 'Print':
         logging.info(args)
 
+def get_tags(ctx: Context):
+    tags = ['Berserker']
+    if ctx.found_items:
+        tags.append('FoundItems')
+    return tags
 
 async def server_auth(ctx: Context, password_requested):
     if password_requested and not ctx.password:
@@ -749,11 +754,8 @@ async def server_auth(ctx: Context, password_requested):
         return
     ctx.awaiting_rom = False
     ctx.auth = ctx.rom.copy()
-    tags = ['Berserker']
-    if ctx.found_items:
-        tags.append('FoundItems')
     await send_msgs(ctx.socket, [['Connect', {
-        'password': ctx.password, 'rom': ctx.auth, 'version': [1, 2, 0], 'tags': tags
+        'password': ctx.password, 'rom': ctx.auth, 'version': [1, 2, 0], 'tags': get_tags(ctx)
     }]])
 
 async def console_input(ctx : Context):
@@ -833,8 +835,7 @@ async def console_loop(ctx : Context):
                 else:
                     ctx.found_items = not ctx.found_items
                 logging.info(f"Set showing team items to {ctx.found_items}")
-                # don't like the reconnect here. Should maybe introduce an update_tags command to the network protocol
-                asyncio.create_task(connect(ctx, None))
+                asyncio.create_task(send_msgs(ctx.socket, [['UpdateTags', get_tags(ctx)]]))
 
             elif precommand == "license":
                 with open("LICENSE") as f:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -57,6 +57,7 @@ class Context:
         self.countdown_timer = 0
         self.clients = []
         self.received_items = {}
+        self.found_items = {}
         self.location_checks = collections.defaultdict(set)
         self.hint_cost = hint_cost
         self.location_check_points = location_check_points
@@ -68,6 +69,7 @@ class Context:
         return {
             "rom_names": list(self.rom_names.items()),
             "received_items": tuple((k, v) for k, v in self.received_items.items()),
+            "found_items": tuple((k, v) for k, v in self.found_items.items()),
             "hints_used" : tuple((key,value) for key, value in self.hints_used.items()),
             "hints_sent" : tuple((key,tuple(value)) for key, value in self.hints_sent.items()),
             "location_checks" : tuple((key,tuple(value)) for key, value in self.location_checks.items())
@@ -76,9 +78,11 @@ class Context:
     def set_save(self, savedata: dict):
         rom_names = savedata["rom_names"]
         received_items = {tuple(k): [ReceivedItem(*i) for i in v] for k, v in savedata["received_items"]}
+        found_items = {tuple(k): [ReceivedItem(*i) for i in v] for k, v in savedata["found_items"]}
         if not all([self.rom_names[tuple(rom)] == (team, slot) for rom, (team, slot) in rom_names]):
             raise Exception('Save file mismatch, will start a new game')
         self.received_items = received_items
+        self.found_items = found_items
         self.hints_used.update({tuple(key): value for key, value in savedata["hints_used"]})
         self.hints_sent.update({tuple(key): set(value) for key, value in savedata["hints_sent"]})
         self.location_checks.update({tuple(key): set(value) for key, value in savedata["location_checks"]})
@@ -134,7 +138,6 @@ def notify_hints(ctx: Context, team: int, hints: typing.List[Utils.Hint]):
             else:
                 payload = texts
             asyncio.create_task(send_msgs(client.socket, payload))
-
 
 async def server(websocket, path, ctx: Context):
     client = Client(websocket)
@@ -213,6 +216,9 @@ def get_connected_players_string(ctx: Context):
 def get_received_items(ctx: Context, team: int, player: int):
     return ctx.received_items.setdefault((team, player), [])
 
+def get_found_items(ctx: Context, team: int, player: int):
+    return ctx.found_items.setdefault((team, player), [])
+
 
 def tuplize_received_items(items):
     return [(item.item, item.location, item.player) for item in items]
@@ -241,21 +247,26 @@ def register_location_checks(ctx: Context, team: int, slot: int, locations):
     for location in locations:
         if (location, slot) in ctx.locations:
             target_item, target_player = ctx.locations[(location, slot)]
-            if target_player != slot or slot in ctx.remote_items:
-                found = False
-                recvd_items = get_received_items(ctx, team, target_player)
-                for recvd_item in recvd_items:
-                    if recvd_item.location == location and recvd_item.player == slot:
-                        found = True
-                        break
+            found = False
+            recvd_items = get_received_items(ctx, team, target_player) if target_player != slot or ctx.remote_items else get_found_items(ctx, team, target_player)
 
-                if not found:
-                    new_item = ReceivedItem(target_item, location, slot)
-                    recvd_items.append(new_item)
-                    if slot != target_player:
-                        broadcast_team(ctx, team, [['ItemSent', (slot, location, target_player, target_item)]])
-                    logging.info('(Team #%d) %s sent %s to %s (%s)' % (team+1, ctx.player_names[(team, slot)], get_item_name_from_id(target_item), ctx.player_names[(team, target_player)], get_location_name_from_address(location)))
-                    found_items = True
+            for recvd_item in recvd_items:
+                if recvd_item.location == location and recvd_item.player == slot:
+                    found = True
+                    break
+
+            if not found:
+                new_item = ReceivedItem(target_item, location, slot)
+                recvd_items.append(new_item)
+                if slot == target_player:
+                    logging.info('(Team #%d) %s found %s (%s)' % (team + 1, ctx.player_names[(team, slot)], get_item_name_from_id(target_item), get_location_name_from_address(location)))
+                    for client in ctx.clients:
+                        if client.auth and client.team == team and "FoundItems" in client.tags:
+                            asyncio.create_task(send_msgs(client.socket, [['ItemFound', (slot, location, target_item)]]))
+                else:
+                    broadcast_team(ctx, team, [['ItemSent', (slot, location, target_player, target_item)]])
+                    logging.info('(Team #%d) %s sent %s to %s (%s)' % (team + 1, ctx.player_names[(team, slot)], get_item_name_from_id(target_item),  ctx.player_names[(team, target_player)], get_location_name_from_address(location)))
+                found_items = True
     send_new_items(ctx)
 
     if found_items:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -409,6 +409,12 @@ async def process_client_cmd(ctx: Context, client: Client, cmd, args):
         logging.info(f"{client.name} in team {client.team+1} scouted {', '.join([l[0] for l in locs])}")
         await send_msgs(client.socket, [['LocationInfo', [l[1:] for l in locs]]])
 
+    if cmd == 'UpdateTags':
+        if not args or type(args) is not list:
+            await send_msgs(client.socket, [['InvalidArguments', 'UpdateTags']])
+            return
+        client.tags = args
+
     if cmd == 'Say':
         if type(args) is not str or not args.isprintable():
             await send_msgs(client.socket, [['InvalidArguments', 'Say']])


### PR DESCRIPTION
Client can opt in to be notified of items found by other players that don't get sent out to another player, either with a command line option `--founditems`,  or while the client is active with `/showfounditems`,  (or opt out after the face with `/hidefounditems`).

The server will only send the found item data to clients that have explicitly opted in on connection.