### PR TITLE
2.1.1 hotfix

### DIFF
--- a/Mystery.py
+++ b/Mystery.py
@@ -185,7 +185,6 @@ def main():
                     important[option] = player_settings
                 else:
                     logging.debug(f"No player settings defined for option '{option}'")
-        print(args.outputpath)
         if args.outputpath:
             os.makedirs(args.outputpath, exist_ok=True)
         with open(os.path.join(args.outputpath if args.outputpath else ".", f"mystery_result_{seed}.yaml"), "wt") as f:

--- a/Mystery.py
+++ b/Mystery.py
@@ -176,15 +176,22 @@ def main():
                 if len(set(player_settings.values())) > 1:
                     important[option] = {player: value for player, value in player_settings.items() if
                                          player <= args.yaml_output}
-                else:
+                elif len(set(player_settings.values())) > 0:
                     important[option] = player_settings[1]
+                else:
+                    logging.debug(f"No player settings defined for option '{option}'")
             else:
                 if player_settings != "":  # is not empty name
                     important[option] = player_settings
-        os.makedirs(args.outputpath, exist_ok=True)
+                else:
+                    logging.debug(f"No player settings defined for option '{option}'")
+        print(args.outputpath)
+        if args.outputpath:
+            os.makedirs(args.outputpath, exist_ok=True)
         with open(os.path.join(args.outputpath if args.outputpath else ".", f"mystery_result_{seed}.yaml"), "wt") as f:
             yaml.dump(important, f)
 
+    logging.info(erargs)
     ERmain(erargs, seed)
 
 

--- a/Utils.py
+++ b/Utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 _version_tuple = tuple(int(piece, 10) for piece in __version__.split("."))
 
 import os


### PR DESCRIPTION
* debug log options that have nothing defined.
* make sure there is at least one value in the dictionary before considering it important.
* only attempt to create outputpath if it is defined.