### PR TITLE
Fix softlock in Enemizer

### DIFF
--- a/Bosses.py
+++ b/Bosses.py
@@ -129,7 +129,7 @@ def can_place_boss(world, player, boss, dungeon_name, level=None):
             return False
 
     if dungeon_name in ['Ganons Tower', 'Inverted Ganons Tower'] and level == 'middle':
-        if boss in ["Blind"]:
+        if boss in ["Blind", "Kholdstare"]:
             return False
 
     if dungeon_name == 'Tower of Hera' and boss in ["Armos Knights", "Arrghus",	"Blind", "Trinexx", "Lanmolas"]:


### PR DESCRIPTION
If you have Kholdstare on GT Lanmolas 2, kill him, walk up and down the following stairs, you softlock. This probably shouldn't be allowed.