### PR TITLE
Retry enemizer up to 15 times, logging the error each time it fails.

### DIFF
--- a/Rom.py
+++ b/Rom.py
@@ -273,7 +273,7 @@ def patch_enemizer(world, player: int, rom: LocalRom, enemizercli, random_sprite
     with open(options_path, 'w') as f:
         json.dump(options, f)
 
-    max_enemizer_tries = 15
+    max_enemizer_tries = 5
     for i in range(max_enemizer_tries):
         enemizer_seed = str(world.rom_seeds[player].randint(0, 999999999))
         enemizer_command = [os.path.abspath(enemizercli),

--- a/Rom.py
+++ b/Rom.py
@@ -273,13 +273,39 @@ def patch_enemizer(world, player: int, rom: LocalRom, enemizercli, random_sprite
     with open(options_path, 'w') as f:
         json.dump(options, f)
 
-    subprocess.check_call([os.path.abspath(enemizercli),
-                           '--rom', randopatch_path,
-                           '--seed', str(world.rom_seeds[player].randint(0, 999999999)),
-                           '--binary',
-                           '--enemizer', options_path,
-                           '--output', enemizer_output_path],
-                          cwd=os.path.dirname(enemizercli))
+    max_enemizer_tries = 15
+    for i in range(max_enemizer_tries):
+        enemizer_seed = str(world.rom_seeds[player].randint(0, 999999999))
+        enemizer_command = [os.path.abspath(enemizercli),
+                            '--rom', randopatch_path,
+                            '--seed', enemizer_seed,
+                            '--binary',
+                            '--enemizer', options_path,
+                            '--output', enemizer_output_path]
+
+        p_open = subprocess.Popen(enemizer_command,
+                                  cwd=os.path.dirname(enemizercli),
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT,
+                                  universal_newlines=True)
+
+        logging.info(f"Enemizer attempt {i + 1} of {max_enemizer_tries} for player {player} using enemizer seed {enemizer_seed}")
+        for stdout_line in iter(p_open.stdout.readline, ""):
+            logging.info(stdout_line.rstrip())
+        p_open.stdout.close()
+
+        return_code = p_open.wait()
+        if return_code:
+            if i == max_enemizer_tries-1:
+                raise subprocess.CalledProcessError(return_code, enemizer_command)
+            continue
+
+        for j in range(i+1, max_enemizer_tries):
+            world.rom_seeds[player].randint(0, 999999999)
+            # Sacrifice all remaining random numbers that would have been used for unused enemizer tries.
+            # This allows for future enemizer bug fixes to NOT affect the rest of the seed's randomness
+        break
+
     rom.read_from_file(enemizer_output_path)
     os.remove(enemizer_output_path)
 


### PR DESCRIPTION
Example of a failure on try one, and a success on the next try.  Anything to allow the seed to still succeed in rolling if at all possible.  Unless there is an unlikely systemic bug in enemizer, it should not need more that at most 2-3 tries.

```
ALttP Berserker's Multiworld Version 2.4.1  -  Seed: 48656113276075124856


Shuffling the World about.
Generating Item Pool.
Calculating Access Rules.
Placing Dungeon Prizes.
Placing Dungeon Items.
Fill the world.
Patching ROM.
Enemizer attempt 1 of 15 for player 1 using enemizer seed 568501612

Unhandled Exception: System.Exception: Shutter room without any killable enemies
   at EnemizerLibrary.Room.RandomizeSprites(Random rand, OptionFlags optionFlags, SpriteGroupCollection spriteGroupCollection, SpriteRequirementCollection spriteRequirementCollection) in H:\DevProjects\Enemizer\EnemizerLibrary\EnemyRandomizer\Dungeon\Room.cs:line 265
   at EnemizerLibrary.DungeonEnemyRandomizer.RandomizeRooms(OptionFlags optionFlags) in H:\DevProjects\Enemizer\EnemizerLibrary\EnemyRandomizer\Dungeon\DungeonEnemyRandomizer.cs:line 61
   at EnemizerLibrary.DungeonEnemyRandomizer.RandomizeDungeonEnemies(OptionFlags optionFlags) in H:\DevProjects\Enemizer\EnemizerLibrary\EnemyRandomizer\Dungeon\DungeonEnemyRandomizer.cs:line 34
   at EnemizerLibrary.Randomization.MakeRandomization(String basePath, Int32 seed, OptionFlags optionflags, RomData romData, String skin) in H:\DevProjects\Enemizer\EnemizerLibrary\Randomization.cs:line 160
   at EnemizerCLI.Core.Program.RandomizeRom(Int32 seed, Byte[] rom_data, OptionFlags optionFlags) in H:\DevProjects\Enemizer\EnemizerCLI.Core\Program.cs:line 99
   at EnemizerCLI.Core.Program.GenerateRom(Int32 seed, Byte[] rom_data, OptionFlags optionFlags) in H:\DevProjects\Enemizer\EnemizerCLI.Core\Program.cs:line 85
   at EnemizerCLI.Core.Program.MakeEnemizerRom(CommandLineOptions options) in H:\DevProjects\Enemizer\EnemizerCLI.Core\Program.cs:line 50
   at EnemizerCLI.Core.Program.<>c.<Main>b__0_2(CommandLineOptions options) in H:\DevProjects\Enemizer\EnemizerCLI.Core\Program.cs:line 30
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at EnemizerCLI.Core.Program.Main(String[] args) in H:\DevProjects\Enemizer\EnemizerCLI.Core\Program.cs:line 20
Enemizer attempt 2 of 15 for player 1 using enemizer seed 947878029
Generated SFC file C:\Users\CaitSith2\Desktop\LttP_MultiWorld\ALttPEntranceRandomizer\multimystery\enemizer_output_1.sfc
Seed generated in: 00:00:00.4356953
Calculating playthrough.
Done. Enjoy.
```

If log_output_path is specified, everything now ends up in the output log.  This did not happen before.