### PR TITLE
Clean up README.md and easy.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Additions/Changes compared to Bonta's V31
 Project
  * Available in precompiled form and guided setup for Windows 64Bit on the [Releases](https://github.com/Berserker66/MultiWorld-Utilities/releases) page
  * Compatible with Python 3.7 and 3.8. Forward Checks for Python 4.0 are done
- * Update modules if they are too old. This prevents crashes when trying to connect among potential other issues
+ * Update modules if they are too old to prevent crashes and other possible issues.
  * Autoinstall missing modules
  * Allow newer versions of modules than specified, as they will *usually* not break compatibility
  * Uses "V32" MSU

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 Berserker's Multiworld
 ======================
 
-A Multiworld implementation for the Legend of Zelda: A Link to the Past Randomizer  
-For setup and instructions there's a [Wiki](https://github.com/Berserker66/MultiWorld-Utilities/wiki)  
+A Multiworld implementation for the Legend of Zelda: A Link to the Past Randomizer.  
+For setup and instructions there's a [Wiki](https://github.com/Berserker66/MultiWorld-Utilities/wiki).  
 Downloads can be found at [Releases](https://github.com/Berserker66/MultiWorld-Utilities/releases), including compiled windows binaries.  
 
 Additions/Changes compared to Bonta's V31
 -----------------
 
 Project
- * Available in precompiled form and guided setup for Windows 64Bit on [Releases](https://github.com/Berserker66/MultiWorld-Utilities/releases) page.
- * Compatible with Python 3.7 and 3.8. Forward Checks for Python 4.0 are done.
- * Update modules if they are too old, preventing a crash when trying to connect among potential other issues
+ * Available in precompiled form and guided setup for Windows 64Bit on the [Releases](https://github.com/Berserker66/MultiWorld-Utilities/releases) page
+ * Compatible with Python 3.7 and 3.8. Forward Checks for Python 4.0 are done
+ * Update modules if they are too old. This prevents crashes when trying to connect among potential other issues
  * Autoinstall missing modules
  * Allow newer versions of modules than specified, as they will *usually* not break compatibility
  * Uses "V32" MSU
@@ -20,45 +20,44 @@ Project
  * Various fixes
  * Overworld Glitches Logic
  * Newer Entrance Randomizer Logic, allowing more potential item and boss locations
- * completely redesigned command interface, with `!help` and `/help`
- * New Goal: local triforce hunt - limits triforce pieces to your own world so it is your own goal to accomplish
+ * New Goal: local triforce hunt - Keeps triforce pieces local to your world
  
 MultiMystery.py
  * Allows you to generate a Multiworld with individual player mystery weights. Since weights can also be set to 100%, this also allows for individual settings for each player in a regular multiworld.
-Basis is a .yaml file that sets these weights. You can find an [easy.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/easy.yaml) in this project folder to get started.
- * Additional instructions are at the start of the file. Open with a text editor.
- * Configuration options in the host.yaml file.
- * Allows a new Mode called "Meta-Mystery", allowing certain mystery settings to apply to all players.
-   * For example, everyone gets the same but random goal.
+Basis is a yaml file that sets these weights. You can find an [easy.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/easy.yaml) in this project folder to get started
+ * Additional instructions are at the start of the file. Open with a text editor
+ * Configuration options can be found in the [host.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/host.yaml) file
+ * Allows a new Mode called "Meta-Mystery", allowing certain mystery settings to apply to all players
+   * For example, everyone gets the same but random goal
  
  MultiServer.py
-  * Supports automatic port-forwarding, can be enabled in host.yaml
-  * improved `!players` command, mentioning how many players are currently connected of how many expected and who's missing
-  * /forfeit Playername now works when the player is not currently connected
-  * Added `/hint` and `!hint`, configuration in host.yaml and description in help
-  * various commands, like /send and /hint use "fuzzy text matching", no longer requiring you to enter a location, player name or item name perfectly
+  * Supports automatic port-forwarding, can be enabled in [host.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/host.yaml)
+  * Added commands `/hint` and `!hint`. See [host.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/host.yaml) for more information
+  * Updates have been made to the following commands:
+    * `!players` now displays the number of connected players, expected total player count, and which players are missing
+    * `forfiet` now works when a player is no longer connected
+    * `/send`, `/hint`, and various other commands now use "fuzzy text matching". It is no longer required to enter a location, player name or item name perfectly
   * Some item groups also exist, so `/hint Bottles` lists all bottle varieties
 
 Mystery.py
- * Defaults to generating a non-race ROM (Bonta's only makes race ROMs at this time)
+ * Defaults to generating a non-race ROM (Bonta's only makes race ROMs at this time).
 If a race ROM is desired, pass --create-race as argument to it
- * When an error is generated due to a broken .yaml file, it now mentions in the error trace which file, line and character is the culprit
- * Option for progressive items, allowing you to turn them off (see easy.yaml for more info)
- * Rom-Option for extendedmsu (see easy.yaml for more info)
- * Option for "timer"
+ * When an error is generated due to a broken yaml file, it now mentions in the error trace which file, line, and character is the culprit
+ * Option for progressive items, allowing you to turn them off (see [easy.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/easy.yaml) for more information)
+ * Option for "timer", allows you to configure a timer to display in game and/or options for timed one hit knock out
  * Option for "dungeon_counters", allowing you to configure the dungeon item counter
  * Option for "glitch_boots", allowing to run glitched modes without automatic boots
  * Supports new Meta-Mystery mode. Read [meta.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/meta.yaml) for details.
- * Added `dungeonssimple` and `dungeonsfull` ER modes
- * Option for local items
+ * Added `dungeonssimple` and `dungeonsfull` entrance randomizer modes
+ * Option for local items, allowing certain items to appear in your world only and not in other players' worlds
  * Option for linked options
  * Added 'l' to dungeon_items to have a local-world keysanity
  
 MultiClient.py
  * Has a Webbrowser based UI now
  * Awaits a QUsb2Snes connection when started, latching on when available
- * completely redesigned command interface, with `!help` and `/help`
+ * Completely redesigned command interface, with `!help` and `/help`
  * Running it with a patch file will patch out the multiworld rom and then automatically connect to the host that created the multiworld
- * Cheating is now controlled by the server and can be disabled through host.yaml
+ * Cheating is now controlled by the server and can be disabled in [host.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/host.yaml)
  * Automatically starts QUsb2Snes, if it isn't running
  * Better reconnect to both snes and server

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Project
  
 MultiMystery.py
  * Allows you to generate a Multiworld with individual player mystery weights. Since weights can also be set to 100%, this also allows for individual settings for each player in a regular multiworld.
-Basis is a yaml file that sets these weights. You can find an [easy.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/easy.yaml) in this project folder to get started
+Basis is a .yaml file that sets these weights. You can find an [easy.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/easy.yaml) in this project folder to get started
  * Additional instructions are at the start of the file. Open with a text editor
  * Configuration options can be found in the [host.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/host.yaml) file
  * Allows a new Mode called "Meta-Mystery", allowing certain mystery settings to apply to all players
@@ -35,14 +35,14 @@ Basis is a yaml file that sets these weights. You can find an [easy.yaml](https:
   * Added commands `/hint` and `!hint`. See [host.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/host.yaml) for more information
   * Updates have been made to the following commands:
     * `!players` now displays the number of connected players, expected total player count, and which players are missing
-    * `forfiet` now works when a player is no longer connected
+    * `forfeit` now works when a player is no longer connected
     * `/send`, `/hint`, and various other commands now use "fuzzy text matching". It is no longer required to enter a location, player name or item name perfectly
   * Some item groups also exist, so `/hint Bottles` lists all bottle varieties
 
 Mystery.py
  * Defaults to generating a non-race ROM (Bonta's only makes race ROMs at this time).
 If a race ROM is desired, pass --create-race as argument to it
- * When an error is generated due to a broken yaml file, it now mentions in the error trace which file, line, and character is the culprit
+ * When an error is generated due to a broken .yaml file, it now mentions in the error trace which file, line, and character is the culprit
  * Option for progressive items, allowing you to turn them off (see [easy.yaml](https://github.com/Berserker66/MultiWorld-Utilities/blob/master/easy.yaml) for more information)
  * Option for "timer", allows you to configure a timer to display in game and/or options for timed one hit knock out
  * Option for "dungeon_counters", allowing you to configure the dungeon item counter

--- a/easy.yaml
+++ b/easy.yaml
@@ -21,8 +21,8 @@ description: Your Description Here # Used to describe your yaml. Useful if you h
 name: YourName # Your name in-game. Spaces and underscores will be replaced with dashes
 glitches_required: # Determine the logic required to complete the seed
   none: 1 # No glitches required
-  minor_glitches: 0 # Puts fake flipper and super bunny shenanigans into logic
-  overworld_glitches: 0 # Assumes the player knows how to perform overworld glitches like fake flipper, water walk, etc
+  minor_glitches: 0 # Puts fake flipper, waterwalk, super bunny shenanigans, and etc into logic
+  overworld_glitches: 0 # Assumes the player has knowledge of both overworld major glitches (boots clips, mirror clips) and minor glitches (fake flipper, super bunny shenanigans, water walk and etc.)
   no_logic: 0 # Items are places completely at random and with no regard for logic. Your fire rod could be on Trinexx
 meta_ignore: # Nullify options specified in the meta.yaml file. Adding an option here guarantees it will not occur in your seed, even if the .yaml file specifies it
   world_state:


### PR DESCRIPTION
This pull request provides additional clean up to the README.md and easy.yaml file at the root of the project. Admittedly, I may have inaccurately interpreted the original intend of some of the bullets and as such my apologies for anything I misinterpreted. It looks like MSU support was removed from the easy.yaml in this [commit](https://github.com/Berserker66/MultiWorld-Utilities/commit/7f66133d379ad661968f107f76172f152174bbed#diff-28113ab2481a9f388e0c8132ca52acb8) so I removed it from the README.md as well. The only other significant changes I made were around the bullet structure of the commands information in the `MultiServer.py` section. There are still some portions I feel could use additional revisions but this felt like a good starting point.