### PR TITLE
Fixed issues with customitemarray

### DIFF
--- a/Gui.py
+++ b/Gui.py
@@ -557,8 +557,8 @@ def guiMain(args=None):
                                    int(rupee20Var.get()), int(rupee50Var.get()), int(rupee100Var.get()),
                                    int(rupee300Var.get()), int(rupoorVar.get()), int(blueclockVar.get()),
                                    int(greenclockVar.get()), int(redclockVar.get()), int(progbowVar.get()),
-                                   int(bomb10Var.get()), int(triforceVar.get()),
-                                   int(rupoorcostVar.get()), int(universalkeyVar.get())]
+                                   int(bomb10Var.get()), int(universalkeyVar.get()),
+                                   int(rupoorcostVar.get()), int(triforceVar.get())]
         guiargs.rom = romVar.get()
         guiargs.create_diff = patchesVar.get()
         guiargs.sprite = sprite

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -785,6 +785,7 @@ def make_custom_item_pool(world, player):
     pool.extend(['Red Clock'] * customitemarray[63])
     pool.extend(['Progressive Bow'] * customitemarray[64])
     pool.extend(['Bombs (10)'] * customitemarray[65])
+    pool.extend(['Triforce'] * customitemarray[68])
 
     diff = difficulties[difficulty]
 

--- a/ItemPool.py
+++ b/ItemPool.py
@@ -48,7 +48,7 @@ Difficulty = namedtuple('Difficulty',
                          'progressive_armor_limit', 'progressive_bottle_limit',
                          'progressive_bow_limit', 'heart_piece_limit', 'boss_heart_container_limit'])
 
-total_items_to_place = 156
+total_items_to_place = 153
 
 difficulties = {
     'easy': Difficulty(
@@ -712,15 +712,16 @@ def make_custom_item_pool(world, player):
         placed_items[loc] = item
 
     # Correct for insanely oversized item counts and take initial steps to handle undersized pools.
-    for x in range(0, 64):
+    for x in range(0, 67):
         if customitemarray[x] > total_items_to_place:
             customitemarray[x] = total_items_to_place
-    if customitemarray[66] > total_items_to_place:
-        customitemarray[66] = total_items_to_place
+    if customitemarray[68] > total_items_to_place:
+        customitemarray[68] = total_items_to_place
+
+    # count all items, except rupoor cost
     itemtotal = 0
-    for x in range(0, 64):
+    for x in range(0, 67):
         itemtotal = itemtotal + customitemarray[x]
-    itemtotal = itemtotal + customitemarray[66]
     itemtotal = itemtotal + customitemarray[68]
 
     pool.extend(['Bow'] * customitemarray[0])


### PR DESCRIPTION
This PR fixes issues with the custom item pool feature. Without changing any values within the Gui, if  thecustom items pool option was enabled, a warning was issued for 6 nothing being added to the pool, and then 6 items from the pool couldn't be placed.

universal keys also wasn't at the right index. I fixed it in gui.py.

TODO: The item "Triforce (win game)" is currently ignored when using a custom item pool