### PR TITLE
Extra Triforce pieces modes

### DIFF
--- a/Mystery.py
+++ b/Mystery.py
@@ -320,9 +320,26 @@ def roll_settings(weights):
 
     ret.crystals_ganon = get_choice('ganon_open', weights)
 
-    ret.triforce_pieces_available = get_choice('triforce_pieces_available', weights, 30)
-    ret.triforce_pieces_available = min(max(1, int(ret.triforce_pieces_available)), 90)
+    extra_pieces = get_choice('triforce_pieces_mode', weights, 'available');
 
+    ret.triforce_pieces_required = get_choice('triforce_pieces_required', weights, 20)
+    ret.triforce_pieces_required = min(max(1, int(ret.triforce_pieces_required)), 90)
+
+    # sum a percentage to required
+    if extra_pieces == 'percentage':
+        percentage = max(100,get_choice('triforce_pieces_percentage',weights,150))/100
+        ret.triforce_pieces_available = int(ret.triforce_pieces_required * percentage)
+    # vanilla mode (specify how many pieces are)
+    elif extra_pieces == 'available':
+        ret.triforce_pieces_available = get_choice('triforce_pieces_available',weights,30)
+    # required pieces + fixed extra
+    elif extra_pieces == 'extra':
+        extra_pieces = max(0, get_choice('triforce_pieces_extra',weights,10))
+        ret.triforce_pieces_available = ret.triforce_pieces_required + extra_pieces
+
+    # change minimum to required pieces to avoid problems
+    ret.triforce_pieces_available = min(max(ret.triforce_pieces_required, int(ret.triforce_pieces_available)), 90) 
+    
     ret.triforce_pieces_required = get_choice('triforce_pieces_required', weights, 20)
     ret.triforce_pieces_required = min(max(1, int(ret.triforce_pieces_required)), 90)
 

--- a/WebHostLib/static/static/playerSettings.json
+++ b/WebHostLib/static/static/playerSettings.json
@@ -346,6 +346,32 @@
         }
       }
     },
+	"triforce_pieces_mode": {
+	  "keyString": "triforce_pieces_mode",
+      "friendlyName": "Triforce Pieces Mode",
+      "description": "Determines how to determine how many extra Triforce pieces will be available",
+      "inputType": "range",
+      "subOptions": {
+        "available": {
+          "keyString": "triforce_pieces_mode.available",
+          "friendlyName": "Available",
+          "description": "Determine the total number of pieces available in \"Triforce pieces available\"",
+          "defaultValue": 50
+        },
+        "extra": {
+          "keyString": "triforce_pieces_mode.extra",
+          "friendlyName": "Extra",
+          "description": "Determine how many extra pieces will be available in \"Extra Triforce pieces quantity\"",
+          "defaultValue": 0
+        },
+        "percentage": {
+          "keyString": "triforce_pieces_mode.percentage",
+          "friendlyName": "Percentage",
+          "description": "Determine the available pieces using a percentage of the required ones using the \"Extra Triforce pieces percentage\"",
+          "defaultValue": 0
+        }
+      }
+	},
     "triforce_pieces_available": {
       "keyString": "triforce_pieces_available",
       "friendlyName": "Triforce Pieces Available",
@@ -375,6 +401,70 @@
           "friendlyName": 50,
           "description": "50 Triforce pieces will be hidden throughout Hyrule",
           "defaultValue": 50
+        }
+      }
+    },
+	"triforce_pieces_extra": {
+      "keyString": "triforce_pieces_extra",
+      "friendlyName": "Extra Triforce Pieces",
+      "description": "Determine how many extra pieces will be available",
+      "inputType": "range",
+      "subOptions": {
+        "0": {
+          "keyString": "triforce_pieces_extra.0",
+          "friendlyName": 0,
+          "description": "No extra Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 0
+        },
+        "5": {
+          "keyString": "triforce_pieces_extra.5",
+          "friendlyName": 5,
+          "description": "5 extra Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 50
+        },
+        "10": {
+          "keyString": "triforce_pieces_extra.10",
+          "friendlyName": 10,
+          "description": "10 extra Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 50
+        },
+        "15": {
+          "keyString": "triforce_pieces_extra.15",
+          "friendlyName": 15,
+          "description": "15 extra Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 0
+        },
+		"20": {
+          "keyString": "triforce_pieces_extra.20",
+          "friendlyName": 20,
+          "description": "20 extra Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 0
+        }
+      }
+    },
+	"triforce_pieces_percentage": {
+      "keyString": "triforce_pieces_percentage",
+      "friendlyName": "Extra Triforce Pieces Percentage",
+      "description": "Determine how many extra pieces will be available, according to a percentage of the required ones",
+      "inputType": "range",
+      "subOptions": {
+        "100": {
+          "keyString": "triforce_pieces_percentage.100",
+          "friendlyName": "100%",
+          "description": "No extra Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 0
+        },
+        "150": {
+          "keyString": "triforce_pieces_percentage.150",
+          "friendlyName": "150%",
+          "description": "Half the required Triforce pieces will be added",
+          "defaultValue": 50
+        },
+        "200": {
+          "keyString": "triforce_pieces_percentage.200",
+          "friendlyName": "200%",
+          "description": "The double of the required Triforce pieces will be hidden throughout Hyrule",
+          "defaultValue": 0
         }
       }
     },

--- a/WebHostLib/static/static/playerSettings.yaml
+++ b/WebHostLib/static/static/playerSettings.yaml
@@ -86,6 +86,22 @@ goals:
   local_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout your world, then turn them in to Murahadala in front of Hyrule Castle
   ganon_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout the worlds, then kill Ganon
   local_ganon_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout your world, then kill Ganon
+triforce_pieces_mode: #Determine how to calculate the extra available triforce pieces.
+  extra: 0 # available = triforce_pieces_extra + triforce_pieces_required
+  percentage: 0 # available = (triforce_pieces_percentage /100) * triforce_pieces_required
+  available: 50 # available = triforce_pieces_available
+triforce_pieces_extra: # Set to how many extra triforces pieces are available to collect in the world. 
+  # Format "pieces: chance"
+  0: 0
+  5: 50
+  10: 50
+  15: 0
+  20: 0
+triforce_pieces_percentage: # Set to how many extra triforces pieces according to a percentage of the required ones, are available to collect in the world. 
+  # Format "pieces: chance"
+  0: 0 #No extra
+  150: 50 #Half the required will be added as extra
+  200: 0 #There are the double of the required ones available.
 triforce_pieces_available: # Set to how many triforces pieces are available to collect in the world. Default is 30. Max is 90, Min is 1
   # Format "pieces: chance"
   25: 0

--- a/WebHostLib/static/static/playerSettings.yaml
+++ b/WebHostLib/static/static/playerSettings.yaml
@@ -99,7 +99,7 @@ triforce_pieces_extra: # Set to how many extra triforces pieces are available to
   20: 0
 triforce_pieces_percentage: # Set to how many extra triforces pieces according to a percentage of the required ones, are available to collect in the world. 
   # Format "pieces: chance"
-  0: 0 #No extra
+  100: 0 #No extra
   150: 50 #Half the required will be added as extra
   200: 0 #There are the double of the required ones available.
 triforce_pieces_available: # Set to how many triforces pieces are available to collect in the world. Default is 30. Max is 90, Min is 1

--- a/playerSettings.yaml
+++ b/playerSettings.yaml
@@ -86,6 +86,22 @@ goals:
   local_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout your world, then turn them in to Murahadala in front of Hyrule Castle
   ganon_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout the worlds, then kill Ganon
   local_ganon_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout your world, then kill Ganon
+triforce_pieces_mode: #Determine how to calculate the extra available triforce pieces.
+  extra: 0 # available = triforce_pieces_extra + triforce_pieces_required
+  percentage: 100 # available = (triforce_pieces_percentage /100) * triforce_pieces_required
+  available: 0 # available = triforce_pieces_available
+triforce_pieces_extra: # Set to how many extra triforces pieces are available to collect in the world. 
+  # Format "pieces: chance"
+  0: 0
+  5: 50
+  10: 50
+  15: 0
+  20: 0
+triforce_pieces_percentage: # Set to how many extra triforces pieces according to a percentage of the required ones, are available to collect in the world. 
+  # Format "pieces: chance"
+  0: 0 #No extra
+  150: 50 #Half the required will be added as extra
+  200: 0 #There are the double of the required ones available.
 triforce_pieces_available: # Set to how many triforces pieces are available to collect in the world. Default is 30. Max is 90, Min is 1
   # Format "pieces: chance"
   25: 0
@@ -94,8 +110,8 @@ triforce_pieces_available: # Set to how many triforces pieces are available to c
   50: 0
 triforce_pieces_required: # Set to how many out of X triforce pieces you need to win the game in a triforce hunt. Default is 20. Max is 90, Min is 1
   # Format "pieces: chance"
-  15: 0
-  20: 50
+  15: 100
+  20: 0
   30: 0
   40: 0
   50: 0

--- a/playerSettings.yaml
+++ b/playerSettings.yaml
@@ -99,7 +99,7 @@ triforce_pieces_extra: # Set to how many extra triforces pieces are available to
   20: 0
 triforce_pieces_percentage: # Set to how many extra triforces pieces according to a percentage of the required ones, are available to collect in the world. 
   # Format "pieces: chance"
-  0: 0 #No extra
+  100: 0 #No extra
   150: 50 #Half the required will be added as extra
   200: 0 #There are the double of the required ones available.
 triforce_pieces_available: # Set to how many triforces pieces are available to collect in the world. Default is 30. Max is 90, Min is 1

--- a/playerSettings.yaml
+++ b/playerSettings.yaml
@@ -88,8 +88,8 @@ goals:
   local_ganon_triforce_hunt: 0 # Collect 20 of 30 Triforce pieces spread throughout your world, then kill Ganon
 triforce_pieces_mode: #Determine how to calculate the extra available triforce pieces.
   extra: 0 # available = triforce_pieces_extra + triforce_pieces_required
-  percentage: 100 # available = (triforce_pieces_percentage /100) * triforce_pieces_required
-  available: 0 # available = triforce_pieces_available
+  percentage: 0 # available = (triforce_pieces_percentage /100) * triforce_pieces_required
+  available: 50 # available = triforce_pieces_available
 triforce_pieces_extra: # Set to how many extra triforces pieces are available to collect in the world. 
   # Format "pieces: chance"
   0: 0
@@ -110,8 +110,8 @@ triforce_pieces_available: # Set to how many triforces pieces are available to c
   50: 0
 triforce_pieces_required: # Set to how many out of X triforce pieces you need to win the game in a triforce hunt. Default is 20. Max is 90, Min is 1
   # Format "pieces: chance"
-  15: 100
-  20: 0
+  15: 0
+  20: 50
   30: 0
   40: 0
   50: 0


### PR DESCRIPTION
I implemented what Dewin suggested on discord.

Added modes to calculate the extra available triforce pieces in mystery seeds:
available: classic mode
extra: available= required+extra [minimum 0, no maximum but total is limited to 90]
percentage : available =required*(percentage/100) [round up] [minimum 100, no max but still limits the total available to 90]

I think i added all that was needed so it could appear in the player settings generator as well but if something is missing, feel free to tell me.