### PR TITLE
Fix missing ellipsis in credits text

### DIFF
--- a/Text.py
+++ b/Text.py
@@ -1230,7 +1230,8 @@ class GoldCreditMapper(CharTextMapper):
 
 class GreenCreditMapper(CharTextMapper):
     char_map = {' ': 0x9F,
-                '·': 0x52}
+                '·': 0x52,
+                '.': 0x52}
     alpha_offset = -0x29
 
 class RedCreditMapper(CharTextMapper):


### PR DESCRIPTION
Aliases the period to the same character as the middle dot, so the "sleeps again..." text looks correct.

Yes, this is an incredibly minor thing, but it does bother me seeing it at the end of every multiworld I do.